### PR TITLE
[feat]아이템 데이터베이스 추가, 아이템 드롭시 약간의 움직임 추가

### DIFF
--- a/Assets/00WorkSpace/NTJ/Scene/NTJTestScene.unity
+++ b/Assets/00WorkSpace/NTJ/Scene/NTJTestScene.unity
@@ -220,7 +220,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9bb1c316468fbbf45af971e7ccff281b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  spriteRenderer: {fileID: 0}
 --- !u!58 &108873363
 CircleCollider2D:
   m_ObjectHideFlags: 0
@@ -636,6 +635,52 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1841238359
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1841238361}
+  - component: {fileID: 1841238360}
+  m_Layer: 0
+  m_Name: ItemObjectPool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1841238360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841238359}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b4c60e1ed0931843b2bf16ca3a506e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemPrefab: {fileID: 0}
+  poolSize: 20
+--- !u!4 &1841238361
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841238359}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.16224547, y: -1.0716422, z: -0.004500015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2087964639
 GameObject:
   m_ObjectHideFlags: 0
@@ -728,6 +773,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1346334889331984504, guid: 2d992b4fa354eed4e9a8a1e76011278e, type: 3}
+      propertyPath: sceneViewId
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 1383580908826063834, guid: 2d992b4fa354eed4e9a8a1e76011278e, type: 3}
       propertyPath: m_Name
       value: max-potion
@@ -825,6 +874,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 984106346556946955, guid: 1ab3a76bf5c9ea446abca4f7e181b9bb, type: 3}
+      propertyPath: sceneViewId
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 990961191659354601, guid: 1ab3a76bf5c9ea446abca4f7e181b9bb, type: 3}
       propertyPath: m_Name
       value: hyper-potion
@@ -842,6 +895,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -4543267870104008952, guid: 16a5e41a25419be46a18f22c33d6e4b3, type: 3}
+      propertyPath: sceneViewId
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 1216565712871941139, guid: 16a5e41a25419be46a18f22c33d6e4b3, type: 3}
       propertyPath: m_Name
       value: potion
@@ -899,6 +956,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -2566942423891263383, guid: 36ff2bc8aafb8e044a6a35421d10f450, type: 3}
+      propertyPath: sceneViewId
+      value: 7
+      objectReference: {fileID: 0}
     - target: {fileID: 1440612547208474148, guid: 36ff2bc8aafb8e044a6a35421d10f450, type: 3}
       propertyPath: m_Name
       value: x-sp-atk
@@ -1013,6 +1074,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 729332628508293318, guid: 35b30b400f69e5846a1c0256325259fb, type: 3}
+      propertyPath: sceneViewId
+      value: 6
+      objectReference: {fileID: 0}
     - target: {fileID: 2934479061330238107, guid: 35b30b400f69e5846a1c0256325259fb, type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.86
@@ -1070,6 +1135,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4061156206373590496, guid: 5140c897943835c41aca823faefc52e7, type: 3}
+      propertyPath: sceneViewId
+      value: 8
+      objectReference: {fileID: 0}
     - target: {fileID: 5157783569865964555, guid: 5140c897943835c41aca823faefc52e7, type: 3}
       propertyPath: m_Name
       value: x-speed
@@ -1127,6 +1196,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -6153215709754872118, guid: f1c4359849ec2884da690a9e4cc4fe03, type: 3}
+      propertyPath: sceneViewId
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 3447596192043297486, guid: f1c4359849ec2884da690a9e4cc4fe03, type: 3}
       propertyPath: m_LocalPosition.x
       value: -1.5136977
@@ -1184,6 +1257,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: -5496836136749494468, guid: 8265e5423fc6fc14a98a202abb9563e2, type: 3}
+      propertyPath: sceneViewId
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 1433496708361366957, guid: 8265e5423fc6fc14a98a202abb9563e2, type: 3}
       propertyPath: m_Name
       value: x-attack
@@ -1251,3 +1328,4 @@ SceneRoots:
   - {fileID: 4239503787895103025}
   - {fileID: 6607847280562906933}
   - {fileID: 8783927855296869326}
+  - {fileID: 1841238361}

--- a/Assets/00WorkSpace/NTJ/Scripts/ItemDrop.cs
+++ b/Assets/00WorkSpace/NTJ/Scripts/ItemDrop.cs
@@ -9,6 +9,14 @@ namespace NTJ
         [SerializeField] private List<ItemData> possibleDrops;
         [SerializeField][Range(0f, 1f)] private float dropChance = 0.3f;
 
+        private void Awake()
+        {
+            if (possibleDrops == null || possibleDrops.Count == 0)
+            {
+                possibleDrops = new List<ItemData>(ItemDatabase.Instance.items);
+            }
+        }
+
         public void OnDeath()
         {
             if (!PhotonNetwork.IsMasterClient) return;
@@ -24,13 +32,23 @@ namespace NTJ
                 int index = Random.Range(0, possibleDrops.Count);
                 int itemId = possibleDrops[index].id;
 
-                var item = ItemObjectPool.Instance.SpawnItem(transform.position, itemId);
+                SpawnItemWithForce(transform.position, itemId);
+            }
+        }
+        public void SpawnItemWithForce(Vector3 position, int itemId)
+        {
+            var item = ItemObjectPool.Instance.SpawnItem(position, itemId);
 
-                if (item.TryGetComponent<Rigidbody2D>(out var rb))
-                {
-                    Vector2 randomForce = Random.insideUnitCircle.normalized * 3f;
-                    rb.AddForce(randomForce, ForceMode2D.Impulse);
-                }
+            if (item != null && item.TryGetComponent<Rigidbody2D>(out var rb))
+            {
+                // ·£´ý ¹æÇâÀÇ ´ÜÀ§ º¤ÅÍ »ý¼º
+                Vector2 randomDir = Random.insideUnitCircle.normalized;
+
+                // Èû Å©±â ¼³Á¤
+                float forceMagnitude = 3f;
+
+                // Èû Àû¿ë
+                rb.AddForce(randomDir * forceMagnitude, ForceMode2D.Impulse);
             }
         }
     }

--- a/Assets/00WorkSpace/NTJ/Scripts/TestState.cs
+++ b/Assets/00WorkSpace/NTJ/Scripts/TestState.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace NTJ
 {
-        public class TestState : MonoBehaviourPun, IStatReceiver
+    public class TestState : MonoBehaviourPun, IStatReceiver
     {
         [SerializeField] private SpriteRenderer spriteRenderer;
         [SerializeField] private PlayerModel playerModel;
@@ -21,8 +21,8 @@ namespace NTJ
         public float spA => playerModel.AllStat.SpecialAttack * GetBuffMultiplier(StatType.SpA);
         public float spD => playerModel.AllStat.SpecialDefense * GetBuffMultiplier(StatType.SpD);
         public float spe => playerModel.AllStat.Speed * GetBuffMultiplier(StatType.Spe);
-        
-        
+
+
         public void ApplyStat(ItemData item)
         {
             switch (item.itemType)
@@ -101,7 +101,7 @@ namespace NTJ
             buffCoroutines[stat] = StartCoroutine(RemoveBuffAfterDelay(stat, multiplier, duration));
             Debug.Log($"{stat} 버프 시작, 배율: {multiplier}, 지속시간: {duration}s");
         }
-        
+
 
         private IEnumerator RemoveBuffAfterDelay(StatType stat, float multiplier, float duration)
         {

--- a/Assets/Resources/ItemDatabase.asset
+++ b/Assets/Resources/ItemDatabase.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b25775e28a667924f926c83bd894e4f5, type: 3}
+  m_Name: ItemDatabase
+  m_EditorClassIdentifier: 
+  items:
+  - {fileID: 11400000, guid: 4fbeed77944829043a3583bb68edf93e, type: 2}
+  - {fileID: 11400000, guid: 578a0b1c3db285e4cab873d6654ed9a7, type: 2}
+  - {fileID: 11400000, guid: cc88d8b271af0e54fa26a6c8af701714, type: 2}
+  - {fileID: 11400000, guid: ca4d40f3d9624c54e8c8cc0981d71522, type: 2}
+  - {fileID: 11400000, guid: 60d9cfa0db01c714f92f60341a39f3fe, type: 2}
+  - {fileID: 11400000, guid: ddc3fa66d3805064a9f0395914ad76f8, type: 2}
+  - {fileID: 11400000, guid: 9a5b50445da215a488719635653c298d, type: 2}
+  - {fileID: 11400000, guid: 3dfdc425b04361e429ccd21ce22a4cd1, type: 2}
+  - {fileID: 11400000, guid: f3c3bfa4ccfdef9418cedc9fc8366ae0, type: 2}

--- a/Assets/Resources/ItemDatabase.asset.meta
+++ b/Assets/Resources/ItemDatabase.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 333137abab1ae5d4693b92e58e642063
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 요약
아이템 데이터베이스 추가, 아이템 드롭시 약간의 움직임 추가

---

## 작업 내용
아이템 데이터 베이스 스크립터블 오브젝트를 Resources에 추가
맵에 빈 오브젝트에 ItemObjectPool 스크립트를 추가하고 imports 폴더 -> ItemPrefab 폴더에 있는 itemPrefab을 넣으시면 됩니다
itemprefab에 rigidbody2D를 추가하여 몬스터가 사망한 자리에서 약간 옆에 아이템이 떨어지도록 했습니다

----- 사용법 정리 -----

# 1. **ItemDatabase, ItemData (ScriptableObject)**

* **역할:**
  아이템 정보를 에디터에서 손쉽게 만들고 관리하는 데이터베이스 역할.

* **세팅법:**

  * `Assets/Resources` 폴더(없으면 생성) 안에 `ItemDatabase`라는 ScriptableObject 에셋을 생성
    (Unity 메뉴: Assets > Create > ScriptableObjects > ItemDatabase)
  * `ItemDatabase` 안에 여러 `ItemData` (역시 Create > ScriptableObjects > ItemData) 아이템들을 배열로 등록
  * `ItemData` 에는 각 아이템의 ID, 이름, 타입, 효과, 스프라이트 등 정보 입력

* **주의:**

  * 반드시 `Resources` 폴더 안에 있어야 `Resources.Load<ItemDatabase>("ItemDatabase")`가 작동
  * 아이템 ID 중복 주의

---

# 2. **ItemObjectPool**

* **역할:**
  아이템 프리팹을 미리 풀로 만들어 두고 재활용하는 매니저

* **세팅법:**

  * 빈 GameObject 생성 후 `ItemObjectPool` 스크립트 붙이기
  * `itemPrefab` 필드에 아이템 프리팹 할당 (아래 아이템 프리팹 설명 참고)
  * 풀 사이즈 설정(예: 20)

* **아이템 프리팹 세팅 (중요):**

  * SpriteRenderer
  * Collider2D (Is Trigger 체크)
  * Rigidbody2D (Dynamic, Gravity Scale 0, Z축 프리즈)
  * PhotonView (Observe None or 기본값 유지)
  * ItemPickup 스크립트 (위에서 작성한 것)
  * Rigidbody2D와 Collider2D는 물리 튕김과 트리거를 위해 필수

---

# 3. **ItemPickup**

* **붙일 곳:**

  * 위 `itemPrefab`에 붙임 (아이템 프리팹의 핵심 스크립트)

* **역할:**

  * 아이템 ID 초기화 및 스프라이트 설정
  * 플레이어와 충돌 시 아이템 효과를 네트워크상 모든 클라이언트에 적용 (RPC 호출)
  * 획득 후 아이템을 풀로 반환

---

# 4. **ItemDrop**

* **붙일 곳:**

  * 몬스터 GameObject에 붙임

* **역할:**

  * 몬스터가 죽을 때 랜덤 확률로 아이템 드롭 처리
  * `possibleDrops`가 비어 있으면 `ItemDatabase` 전체 아이템 중 랜덤 드롭
  * 아이템 드롭 시 `SpawnItemWithForce` 호출해 위치에 아이템 생성 및 살짝 튕기기 효과 부여

* **사용법:**

  * 몬스터가 죽는 로직 내에 `itemDrop.OnDeath()` 호출

---

# 5. **TestState (또는 IStatReceiver 구현체)**

* **붙일 곳:**

  * 플레이어 GameObject에 붙임 (스탯 관리 담당)

* **역할:**

  * 아이템 사용 시 스탯 적용 (회복, 레벨업, 버프)
  * 버프 지속시간 관리 및 제거
  * 외부에서 `ApplyStat(ItemData)` 호출로 효과 적용

* **주의:**

  * `IStatReceiver` 인터페이스 구현 필수 (RPC로 효과 전달 시 사용)

---

# 6. **IStatReceiver**

* **인터페이스**로 스탯 적용 및 제거 메서드 명시

---

# **추가 팁 & 체크 리스트**

* **Photon 네트워크 세팅**

  * 아이템 프리팹에 `PhotonView` 꼭 붙이고, 풀에서 꺼내 쓸 때 `photonView.TransferOwnership(0)` 하여 씬 소유권으로 설정
  * 몬스터는 마스터 클라이언트가 죽음 판단 후 아이템 생성 담당

* **풀링 시스템**

  * 아이템 생성은 `ItemObjectPool.Instance.SpawnItem`으로 하고, 획득 시 `ReturnToPool` 호출해 비활성화 및 재활용

* **Resources 폴더**

  * `Resources/ItemDatabase.asset` 위치 필수
  * ItemDatabase 안에 여러 ItemData 등록 완료

* **아이템 프리팹 위치**

  * `Assets/Prefabs/Item.prefab` 같은 폴더에 아이템 프리팹 저장하고 `ItemObjectPool`에 연결

* **몬스터 스크립트에 `ItemDrop` 연결**

  * 몬스터가 죽는 시점에 `itemDrop.OnDeath()` 호출해서 아이템 드롭 실행

* **Collider 충돌 Layer 설정**

  * 플레이어와 아이템의 충돌 레이어 설정이 맞는지 확인 (충돌 및 트리거 이벤트가 발생하려면)

---

# **간단 사용 흐름**

1. 플레이어가 몬스터를 죽임 → 몬스터 스크립트에서 `ItemDrop.OnDeath()` 호출
2. `ItemDrop`에서 드롭 확률에 따라 `SpawnItemWithForce` 호출 → 아이템 프리팹 생성 + 튕기기 물리 효과
3. 아이템 프리팹 `ItemPickup` 스크립트가 아이템 ID에 맞는 데이터 세팅 및 스프라이트 설정
4. 플레이어가 아이템에 닿으면 `OnTriggerEnter2D`에서 RPC 호출로 아이템 효과(`ApplyStat`) 네트워크 전파
5. `TestState` 같은 플레이어 컴포넌트가 아이템 효과를 받아 실제 스탯 변경
6. 아이템은 풀로 반환되어 재활용
---

## 스크린샷 / 녹화
(필요하다면 GIF나 스크린샷을 첨부해 주세요)

---

## 테스트 방법
(직접 테스트해보는 방법을 단계별로 적어주세요)
1. 
2. 

---

## 해야 할 일 / 수정 사항
(아직 남아 있는 문제, 추가로 개선할 부분이나 향후 수정이 필요한 내용을 적어주세요)

---

## 체크리스트

- [ ] 코드가 정상적으로 빌드/실행된다
- [ ] 기능이 정상 동작한다
- [ ] 심각한 버그나 예상치 못한 문제는 없다
