### PR TITLE
[FEAT]사운드 재생 통합관리및사운드플레이어

### DIFF
--- a/Assets/00WorkSpace/CJM/Scripts/UI.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c305659df602dea449ae07c324459e02
+guid: 4bdfe8b86bc5c4bad988670915a3698a
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InGameGroup.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InGameGroup.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1fa634f04b47bbc4bbd5db59f9db8633
+guid: b97ff907cd17749c68f05f5080760f22
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InGameGroup/UIGroup_InGame.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InGameGroup/UIGroup_InGame.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cc9b07e9facb6614289bd313645cc0d2
+guid: 467041a9edf3d485c844e5ec89b4e264
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9b9c59938c811324a8ab6b8ee6ef6127
+guid: 9120e0f33c65848aa9dacede4bf4125d
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/Panel_RoomButtons.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/Panel_RoomButtons.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e7dc9e92e67415643a8e529ccfda96d4
+guid: a24cfa6abcb5b4e82bd7fa1dc46eca58
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/Panel_RoomSettings.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/Panel_RoomSettings.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5da9cec60b165ec4a9686cbf565dbd1d
+guid: 7f7faec81b04b4b5782c749979f12695
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/RoomMemberSlot.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/RoomMemberSlot.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 81a502307bfcdcb41ba12312bcde52d5
+guid: 2140b5f555552483b90b5bcdba396b0e
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/UIGroup_Room.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InRoomGroup/UIGroup_Room.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d62218e79b578d4c8ce2d9288a0b8f6
+guid: 91608165d477d42abbed835b2ab16ed7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0962e62fd0a72ea4b8bfb6c88052e22d
+guid: 0423cf6aac12b47a8a0d2d4d1060f8aa
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup/Panel_GuestInit.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup/Panel_GuestInit.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 322a4eaec488afa4cb4158b430874584
+guid: d9edde12fd35f45e3b450553c3ce081d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup/Panel_InitDefault.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup/Panel_InitDefault.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6346a92601e976b41be04960899e11c6
+guid: d354a08655bec4c33b4dd54f4d6479bc
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup/UIGroup_Initialize.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/InitializeGroup/UIGroup_Initialize.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2c4565df1fbedc04e83aec25c85135ac
+guid: e98558a51ed1d475e9d71ef20787ea68
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LoadingGroup/LoadingPanel.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LoadingGroup/LoadingPanel.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f71fd67cb4d54604db94045d69d16859
+guid: 07236d4fa50754fcba6a6ba0d33b51d1
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LoadingGroup/UIGroup_Loading.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LoadingGroup/UIGroup_Loading.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6d763cc2bd11cb3469f4c2548b69ac0e
+guid: b31bbdb0c67634518857b1d2eecd89dd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fce4b131fe0ce794cb5c55611b375a3f
+guid: 9b14032e72e1c4ce5a235ef0575ecde0
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Panel_LobbyDefault.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Panel_LobbyDefault.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 70255a6e156b3c345bacbd3907351d62
+guid: c0c78139a4cd347d994b65b46d72c605
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Panel_RoomInfo.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Panel_RoomInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5fef3d91c24d01f4fb3407709d7b2ffa
+guid: 647a14b7fc81643a381fb6acfad95479
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Panel_RoomMaking.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Panel_RoomMaking.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9ed81a0eb392bb44bbedab0213f3c5d0
+guid: 5ffb3fab34ad1427eaeabf27e29b7c07
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Slot_RoomInfo.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/Slot_RoomInfo.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e87a492d98e43764b88f9fe5502619fa
+guid: 4516272f21a6445ed851f914a10b43d0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/UIGroup_Lobby.cs.meta
+++ b/Assets/00WorkSpace/CJM/Scripts/UI/LobbyGroup/UIGroup_Lobby.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c7666f00feb3cc04288df7d27bd015b5
+guid: 2af959fbac79d4771ae090cca8854340
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/KDJ/Scene.meta
+++ b/Assets/00WorkSpace/KDJ/Scene.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: c522ee39eb421460386a1ce1d17c7640
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/00WorkSpace/KDJ/Scene/New Material.mat
+++ b/Assets/00WorkSpace/KDJ/Scene/New Material.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: New Material
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/00WorkSpace/KDJ/Scene/New Material.mat.meta
+++ b/Assets/00WorkSpace/KDJ/Scene/New Material.mat.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
-folderAsset: yes
-DefaultImporter:
+guid: cb46e5023dc3740d2a2b4e03761e80fe
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 2100000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/00WorkSpace/KDJ/Scene/New Scene.unity
+++ b/Assets/00WorkSpace/KDJ/Scene/New Scene.unity
@@ -1,0 +1,221 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1485952797
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1485952800}
+  - component: {fileID: 1485952799}
+  - component: {fileID: 1485952798}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1485952798
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485952797}
+  m_Enabled: 1
+--- !u!20 &1485952799
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485952797}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1485952800
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1485952797}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1485952800}

--- a/Assets/00WorkSpace/KDJ/Scene/New Scene.unity.meta
+++ b/Assets/00WorkSpace/KDJ/Scene/New Scene.unity.meta
@@ -1,6 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
-folderAsset: yes
+guid: 607efb8c4d8f9449b908d80843e15854
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/00WorkSpace/KDJ/Script.meta
+++ b/Assets/00WorkSpace/KDJ/Script.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: bcf373a928b2d4022b45b63b5c7c0e70
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/00WorkSpace/KDJ/Script/EnemyHealtth.cs
+++ b/Assets/00WorkSpace/KDJ/Script/EnemyHealtth.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+
+public class EnemyHealth : MonoBehaviour
+{
+    public float maxHealth = 50f;   // 적의 최대 체력
+    private float currentHealth;
+
+    void Start()
+    {
+        currentHealth = maxHealth;
+    }
+    /// 데미지를 받는 함수
+    public void TakeDamage(float damage)
+    {
+        currentHealth -= damage;
+        Debug.Log($"{gameObject.name}이(가) {damage} 데미지를 받음. 남은 체력: {currentHealth}");
+
+        if (currentHealth <= 0)
+        {
+            Die();
+        }
+    }
+    /// 적 사망 처리
+    private void Die()
+    {
+        Debug.Log($"{gameObject.name} 사망!");
+        Destroy(gameObject);
+    }
+}

--- a/Assets/00WorkSpace/KDJ/Script/EnemyHealtth.cs.meta
+++ b/Assets/00WorkSpace/KDJ/Script/EnemyHealtth.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e50f2fb7d723b4d4685b762493329c94
+guid: 00a9055a424224ec087e99a2c52e487c
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/KDJ/Script/PlayerSkill.cs
+++ b/Assets/00WorkSpace/KDJ/Script/PlayerSkill.cs
@@ -1,0 +1,122 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerSkillManager : MonoBehaviour
+{
+    [Header("스킬: 돌진")]
+    public float dashCooldown = 5f;       // 돌진 스킬 재사용 대기 시간
+    public float dashForce = 20f;         // 돌진 시 플레이어에게 적용할 힘
+    private bool canDash = true;          // 현재 돌진 스킬 사용 가능 여부
+
+    [Header("스킬: 폭발")]
+    public float explosionCooldown = 8f;  // 폭발 스킬 재사용 대기 시간
+    public GameObject explosionPrefab;    // 폭발 이펙트 프리팹
+    public float explosionDamage = 20f;   // 폭발 데미지
+    public float explosionRadius = 2f;    // 폭발 범위 반경
+    private bool canExplosion = true;     // 현재 폭발 스킬 사용 가능 여부
+
+    [Header("스킬: 힐")]
+    public float healCooldown = 10f;      // 힐 스킬 재사용 대기 시간
+    public int healAmount = 20;           // 힐 시 회복되는 체력량
+    private bool canHeal = true;          // 현재 힐 스킬 사용 가능 여부
+
+    private Rigidbody2D rb;               // 플레이어의 Rigidbody2D 컴포넌트
+    private PlayerHealth playerHealth;    // 플레이어의 체력 관리 스크립트
+
+    void Start()
+    {
+        // 시작 시 필요한 컴포넌트를 가져옴
+        rb = GetComponent<Rigidbody2D>();
+        playerHealth = GetComponent<PlayerHealth>();
+    }
+
+    void Update()
+    {
+        // Space 키를 누르면 돌진 스킬 사용
+        if (Input.GetKeyDown(KeyCode.Space) && canDash)
+            StartCoroutine(Dash());
+
+        // E 키를 누르면 폭발 스킬 사용
+        if (Input.GetKeyDown(KeyCode.E) && canExplosion)
+            StartCoroutine(Explosion());
+
+        // Q 키를 누르면 힐 스킬 사용
+        if (Input.GetKeyDown(KeyCode.Q) && canHeal)
+            StartCoroutine(Heal());
+    }
+
+    /// <summary>
+    /// 돌진 스킬 코루틴.
+    /// 일정 시간 동안 스킬을 재사용하지 못하도록 쿨다운을 적용
+    /// </summary>
+    private IEnumerator Dash()
+    {
+        canDash = false;  // 스킬 사용 불가로 설정
+        Vector2 dashDirection = rb.velocity.normalized; // 현재 이동 방향
+        if (dashDirection == Vector2.zero) dashDirection = Vector2.up; // 멈춘 상태라면 위로 돌진
+        rb.AddForce(dashDirection * dashForce, ForceMode2D.Impulse); // 순간적으로 힘을 줘서 돌진
+        yield return new WaitForSeconds(dashCooldown);// 쿨다운 대기
+        canDash = true;// 스킬 사용 가능
+    }
+
+    /// <summary>
+    /// 폭발 스킬 코루틴.
+    /// 폭발 이펙트를 생성하고 주변 적들에게 데미지를 줌.
+    /// </summary>
+    private IEnumerator Explosion()
+    {
+        canExplosion = false;
+        Instantiate(explosionPrefab, transform.position, Quaternion.identity);// 폭발 이펙트 생성
+
+        // 폭발 범위에 있는 적들에게 데미지 전달
+        Collider2D[] hits = Physics2D.OverlapCircleAll(transform.position, explosionRadius);
+        foreach (var hit in hits)
+        {
+            if (hit.CompareTag("Enemy"))
+            {
+                // 예시: EnemyHealth 스크립트를 가진 적이 있다면 데미지 적용
+                var enemy = hit.GetComponent<EnemyHealth>();
+                if (enemy != null)
+                {
+                    enemy.TakeDamage(explosionDamage);
+                }
+            }
+        }
+
+        yield return new WaitForSeconds(explosionCooldown); // 쿨다운 대기
+        canExplosion = true;
+    }
+
+    /// <summary>
+    /// 힐 스킬 코루틴.
+    /// 플레이어 체력을 회복하고 쿨다운 적용.
+    /// </summary>
+    private IEnumerator Heal()
+    {
+        canHeal = false;
+        playerHealth.Heal(healAmount);// 플레이어 체력 회복
+        yield return new WaitForSeconds(healCooldown);// 쿨다운 대기
+        canHeal = true;
+    }
+
+    /// <summary>
+    /// 스킬 강화 함수 (레벨업 시 호출 가능)
+    /// </summary>
+    /// <param name="dashBoost">돌진력 증가량</param>
+    /// <param name="explosionBoost">폭발 데미지 증가량</param>
+    /// <param name="healBoost">힐량 증가량</param>
+    public void UpgradeSkills(float dashBoost, float explosionBoost, int healBoost)
+    {
+        dashForce += dashBoost;                 // 돌진 속도 강화
+        explosionDamage += explosionBoost;      // 폭발 데미지 강화
+        healAmount += healBoost;                // 힐 회복량 강화
+
+        // 쿨다운을 소폭 줄여서 스킬을 더 자주 사용 가능
+        dashCooldown = Mathf.Max(1f, dashCooldown - 0.5f);
+        explosionCooldown = Mathf.Max(2f, explosionCooldown - 0.5f);
+        healCooldown = Mathf.Max(3f, healCooldown - 0.5f);
+
+        Debug.Log($"스킬 강화됨! 돌진:{dashForce}, 폭발:{explosionDamage}, 힐:{healAmount}");
+    }
+}

--- a/Assets/00WorkSpace/KDJ/Script/PlayerSkill.cs.meta
+++ b/Assets/00WorkSpace/KDJ/Script/PlayerSkill.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e50f2fb7d723b4d4685b762493329c94
+guid: fe3c07d733c67445687a1d925b0c8a1f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/KDJ/Script/ProjectileBase.cs
+++ b/Assets/00WorkSpace/KDJ/Script/ProjectileBase.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ProjectileBase : MonoBehaviour
+{
+    private float damage;// 탄환이 가하는 피해량
+    private float speed;// 탄환의 이동 속도
+    private float lifetime;// 탄환의 수명
+    private string targetTag = "Enemy";// 탄환이 맞춰야 할 대상의 태그
+    /// 탄환 초기화 함수.
+    /// 발사 시 피해량, 속도, 수명을 설정하고,
+    /// 지정된 시간이 지나면 탄환을 자동으로 제거한다.
+    public void Init(float dmg, float spd, float life)
+    {
+        damage = dmg;// 피해량 설정
+        speed = spd;// 속도 설정
+        lifetime = life;// 수명 설정
+        Destroy(gameObject, lifetime); // 수명이 끝나면 게임 오브젝트 자동 파괴
+    }
+    /// 매 프레임마다 호출되어 탄환을 오른쪽 방향Vector2.right으로 이동
+    /// Time.deltaTime을 곱해 프레임 레이트와 상관없이 일정한 속도로 이동
+    void Update()
+    {
+        transform.Translate(Vector2.right * speed * Time.deltaTime);
+    }
+    /// 다른 Collider2D와 충돌했을 때 호출되는 이벤트 함수.
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        // 충돌한 대상이 목표 태그(Enemy)와 일치하면
+        if (collision.CompareTag(targetTag))
+        {
+            // EnemyHealth 스크립트를 가져와서 체력 감소 처리
+            var enemyHealth = collision.GetComponent<EnemyHealth>();
+            if (enemyHealth != null)
+            {
+                enemyHealth.TakeDamage(damage); // 적에게 피해를 준다.
+            }
+            Destroy(gameObject);// 탄환 파괴
+        }
+        // 그렇지 않고, 충돌한 오브젝트가 Ground 레이어라면
+        else if (collision.gameObject.layer == LayerMask.NameToLayer("Ground"))
+        {
+            // 탄환 파괴
+            Destroy(gameObject);
+        }
+    }
+}

--- a/Assets/00WorkSpace/KDJ/Script/ProjectileBase.cs.meta
+++ b/Assets/00WorkSpace/KDJ/Script/ProjectileBase.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e50f2fb7d723b4d4685b762493329c94
+guid: 81bd9a23b566443ca8d2bd4b9b78adc2
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/KDJ/Script/SkillData.cs
+++ b/Assets/00WorkSpace/KDJ/Script/SkillData.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "NewSkill", menuName = "Pokemon/SkillData")]
+public class SkillData : ScriptableObject
+{
+    public string skillName;// 스킬 이름
+    public float damage;// 스킬 데미지
+    public float speed;// 투사체 속도
+    public float lifetime = 3f;// 투사체 생존 시간
+    public GameObject projectilePrefab; // 투사체 프리팹
+}

--- a/Assets/00WorkSpace/KDJ/Script/SkillData.cs.meta
+++ b/Assets/00WorkSpace/KDJ/Script/SkillData.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e50f2fb7d723b4d4685b762493329c94
+guid: 329b688f620bf41da8c4b2504a48e44b
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/00WorkSpace/KDJ/soundScript.meta
+++ b/Assets/00WorkSpace/KDJ/soundScript.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d6e94b6df205d42e0974c7139f04d7a8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00WorkSpace/KDJ/soundScript/AudioManager.cs
+++ b/Assets/00WorkSpace/KDJ/soundScript/AudioManager.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Audio;
+
+public class AudioManager : MonoBehaviour
+{
+    public static AudioManager Instance;// 싱글톤 인스턴스: 어디서든 접근 가능하게 하기 위해 static으로 선언
+
+    [Header("믹서")]
+    public AudioMixer mixer;// Unity에서 오디오 믹서를 사용해 소리의 볼륨 및 이펙트를 제어할 수 있음
+    [Header("오디오 클립")]
+    // 효과음과 배경음으로 사용할 오디오 클립들을 인스펙터에서 지정
+    public AudioClip hitClip;// 피격 효과음
+    public AudioClip itemClip;// 아이템 획득 효과음
+    public AudioClip uiClip;// UI 클릭 효과음
+    public AudioClip bgmClip;// 배경음악
+
+    [Header("오디오 소스")]
+    // 오디오 재생에 사용되는 오디오 소스들
+    public AudioSource sfxSource;// 효과음용 AudioSource 2D
+    public AudioSource bgmSource;// 배경음악용 AudioSource
+
+    private void Awake()
+    {
+        // 싱글톤 초기화: 인스턴스가 없으면 이 객체를 할당, 있으면 중복 제거
+        if (Instance == null)
+            Instance = this;
+        else
+            Destroy(gameObject);
+    }
+
+    private void Start()
+    {
+        PlayBGM(bgmClip);// 게임 시작 시 배경음 자동 재생
+    }
+    public void PlaySFX(AudioClip clip)// 효과음 재생 함수OneShot으로 중복 재생 가능
+    {
+        sfxSource.PlayOneShot(clip);
+    }
+
+    // 각각의 효과음을 편리하게 호출할 수 있는 함수들
+    public void PlayHit() => PlaySFX(hitClip);// 피격 효과음 재생
+    public void PlayItem() => PlaySFX(itemClip);// 아이템 획득 효과음 재생
+    public void PlayUI() => PlaySFX(uiClip);// UI 클릭 효과음 재생
+
+     public void PlayBGM(AudioClip clip)// 배경음 재생 함수 
+    {
+        bgmSource.clip = clip;// 재생할 배경음 지정
+        bgmSource.loop = true;// 반복 재생 설정
+        bgmSource.Play();// 배경음 재생 시작
+    }
+}

--- a/Assets/00WorkSpace/KDJ/soundScript/AudioManager.cs.meta
+++ b/Assets/00WorkSpace/KDJ/soundScript/AudioManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6c04b76e9648442bb76cc434762703a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00WorkSpace/KDJ/soundScript/ItemSoundTrigger.cs
+++ b/Assets/00WorkSpace/KDJ/soundScript/ItemSoundTrigger.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ItemSoundTrigger : MonoBehaviour
+{
+    public SoundPlayer soundPlayer;// 사운드를 재생할 SoundPlayer 스크립트 참조 (해당 오브젝트에 붙어 있어야 함)
+
+    void OnTriggerEnter(Collider other)// 트리거 충돌 감지 다른 콜라이더가 이 오브젝트의 트리거에 닿았을 때 실행됨
+    {
+        if (other.CompareTag("Player"))// 닿은 오브젝트가 Player 태그를 가진 경우
+        {
+            soundPlayer.Play();// 사운드 재생
+            // 이 부분에 아이템 획득 효과나 기능을 추가할 수 있음
+            // 예: 체력 회복, 포인트 추가, 아이템 제거 등
+        }
+    }
+}

--- a/Assets/00WorkSpace/KDJ/soundScript/ItemSoundTrigger.cs.meta
+++ b/Assets/00WorkSpace/KDJ/soundScript/ItemSoundTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 845c16c96d6624552931fda73885077f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00WorkSpace/KDJ/soundScript/SoundPlayer.cs
+++ b/Assets/00WorkSpace/KDJ/soundScript/SoundPlayer.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Audio;
+
+[RequireComponent(typeof(AudioSource))]
+// 이 컴포넌트를 사용하는 gameObject에 AudioSource 컴포넌트가 반드시 포함되도록 강제함
+public class SoundPlayer : MonoBehaviour
+{
+    public AudioClip clip;// 재생할 오디오 클립
+    public AudioMixerGroup mixerGroup;// 사용할 오디오 믹서 그룹 예: SFX, UI, BGM 등
+    public bool playOnAwake = false;// true면 오브젝트 생성 시 자동 재생
+    public bool is3D = false;// true면 3D 사운드거리 기반, false면 2D 사운드
+
+    private AudioSource audioSource;// 오디오 재생용 AudioSource 참조
+
+    void Awake()
+    {
+        audioSource = GetComponent<AudioSource>(); // AudioSource 컴포넌트 가져오기
+        audioSource.outputAudioMixerGroup = mixerGroup;// 오디오 믹서 그룹 설정 BGM/SFX/UI 등 분리 재생 조절 가능
+        audioSource.playOnAwake = playOnAwake;// 시작 시 자동 재생 여부 설정
+        audioSource.spatialBlend = is3D ? 1f : 0f;// 3D/2D 사운드 설정,0 = 완전한 2D 사운드,1 = 완전한 3D 사운드
+    }
+
+    public void Play() // 외부에서 수동으로 호출하여 효과음 재생
+    {
+        if (clip != null)
+        {
+            audioSource.PlayOneShot(clip);// 지정된 오디오 클립을 OneShot으로 재생
+            //OneShot은 중복 재생 가능하며 clip 설정을 바꾸지 않음
+        }
+    }
+}

--- a/Assets/00WorkSpace/KDJ/soundScript/SoundPlayer.cs.meta
+++ b/Assets/00WorkSpace/KDJ/soundScript/SoundPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bc00812e673b4d4b8e80d2ddce0b90e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ExternalDependencyManager.meta
+++ b/Assets/ExternalDependencyManager.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: bda7e8669d35c4bd5861ff08b324ca4f
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/ExternalDependencyManager/Editor.meta
+++ b/Assets/ExternalDependencyManager/Editor.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: 2ba3e538ce1d149beb27f1b4f637fff6
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/ExternalDependencyManager/Editor/1.2.186.meta
+++ b/Assets/ExternalDependencyManager/Editor/1.2.186.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: aabba6012e10a4e70809d2cca5e13246
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Firebase.meta
+++ b/Assets/Firebase.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: 43447ac79a50a4cebb3162b2bbbead65
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Firebase/Editor.meta
+++ b/Assets/Firebase/Editor.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: 8a0fb4ad6812c4152a3beb74508e7876
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Firebase/Plugins.meta
+++ b/Assets/Firebase/Plugins.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: 5a5a9f6b1fe12498eab92e1b4849d23c
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/Firebase/Plugins/iOS.meta
+++ b/Assets/Firebase/Plugins/iOS.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f2c132a93ee9b4d4e922fbcf7d8aa7f9
+guid: f795752784f5f4cb5a2b3c6751ae3dd2
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.7",
     "com.unity.timeline": "1.7.7",
+    "com.unity.toolchain.macos-arm64-linux-x86_64": "2.0.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.9.4",
     "com.veriorpies.parrelsync": "https://github.com/VeriorPies/ParrelSync.git?path=/ParrelSync",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -188,6 +188,22 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.sysroot": {
+      "version": "2.0.10",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.9",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.33",
       "depth": 0,
@@ -217,6 +233,16 @@
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.macos-arm64-linux-x86_64": {
+      "version": "2.0.4",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.10",
+        "com.unity.sysroot.linux-x86_64": "2.0.9"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
## 요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)

AudioManager:게임전반에서 사운드 재생 통합관리를해주는 싱클톤오디오 컨트롤러
효과음오디오 소스를 주로 2d로 설정
배경음을 오디오소스 반복 재생 설정포함

SoundPlayer:오디오 효과음을 객체별로 독립적으로 재생가능
사운드를 짧고 간단하게 재생하고 싶을떄 유용하게사용
개별 오브젝트가 자신만의 사운드를 재생할수 있도록 설정하는 재사용 가능한 스크립트
각각의 오브젝트에 사운드플레이어 이스크립트만 붙히면 사운드 재생을 가능하게 해준다.

itemsoundtrigger:플레이어가 아이템과 충돌했을떄 효과음을 재생하는 역할 흔히 아이템 획득했을때 나는 소리
특정 오브젝트에 부착되면 플레이어가 트리거안에 들어오면 사운드를 재생하게한다
사운드 재생은 soundplayer여기에 스크립트를 통해 처리된다.
---

## 작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 작업 1
- 작업 2

---

## 스크린샷 / 녹화
(필요하다면 GIF나 스크린샷을 첨부해 주세요)

---

## 테스트 방법
(직접 테스트해보는 방법을 단계별로 적어주세요)
1. 
2. 

---

## 해야 할 일 / 수정 사항
(아직 남아 있는 문제, 추가로 개선할 부분이나 향후 수정이 필요한 내용을 적어주세요)

---

## 체크리스트

- [ ] 코드가 정상적으로 빌드/실행된다
- [ ] 기능이 정상 동작한다
- [ ] 심각한 버그나 예상치 못한 문제는 없다
