### PR TITLE
[FEAT]아이탬줍기및플레이어경험치 사운드

### DIFF
--- a/Assets/00WorkSpace/KDJ/soundScript/CombatSoundTrigger.cs
+++ b/Assets/00WorkSpace/KDJ/soundScript/CombatSoundTrigger.cs
@@ -1,0 +1,19 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CombatSoundTrigger : MonoBehaviour
+{
+
+    public SoundPlayer attackSound;// 공격 사운드를 재생할 SoundPlayer
+    public SoundPlayer hitSound; // 피격 사운드를 재생할 SoundPlayer
+
+    public void PlayAttackSound()// 공격 시 호출되는 메서드: 공격 사운드 재생
+    {
+        attackSound.Play();
+    }
+    public void PlayHitSound()// 피격 시 호출되는 메서드: 피격 사운드 재생
+    {
+        hitSound.Play();
+    }
+}

--- a/Assets/00WorkSpace/KDJ/soundScript/CombatSoundTrigger.cs.meta
+++ b/Assets/00WorkSpace/KDJ/soundScript/CombatSoundTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f88183727b5244afa5f9738949d756e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00WorkSpace/KDJ/soundScript/ItemPickupSound.cs
+++ b/Assets/00WorkSpace/KDJ/soundScript/ItemPickupSound.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Audio;
+
+// 아이템에 붙이는 스크립트: 플레이어가 가까이 왔을 때 사운드를 재생 거리 기반 처리 포함
+public class ItemPickupSound : MonoBehaviour
+{
+    public AudioClip pickupClip;// 아이템 획득 시 재생할 오디오 클립
+    public AudioMixerGroup fxGroup;// FX 믹서 그룹 효과음용.
+    private void OnTriggerEnter2D(Collider2D collision)// 플레이어가 2D 트리거에 진입할 때 호출
+    {
+        if (collision.CompareTag("Player"))// 플레이어와 충돌했는지 확인
+        {
+            // 새로운 GameObject를 만들어 거리 기반 사운드를 재생할 AudioSource 추가
+            var audio = new GameObject("PickupSound").AddComponent<AudioSource>();
+
+            audio.clip = pickupClip;// 클립 설정
+            audio.outputAudioMixerGroup = fxGroup;// 믹서 그룹 설정 FX 그룹
+            audio.spatialBlend = 1f;// 3D 사운드 설정 거리 기반
+            audio.minDistance = 1f;// 소리 최대로 크게 들리는 거리
+            audio.maxDistance = 10f;// 소리가 들릴 수 있는 최대 거리
+            audio.Play();// 사운드 재생
+
+            Destroy(audio.gameObject, 2f);// 2초 후 오디오 오브젝트 제거
+        }
+    }
+}

--- a/Assets/00WorkSpace/KDJ/soundScript/ItemPickupSound.cs.meta
+++ b/Assets/00WorkSpace/KDJ/soundScript/ItemPickupSound.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd20e8c3f78de43bf87c3c0959d19491
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00WorkSpace/KDJ/soundScript/SmartSoundTrigger.cs
+++ b/Assets/00WorkSpace/KDJ/soundScript/SmartSoundTrigger.cs
@@ -1,0 +1,48 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SmartSoundTrigger : MonoBehaviour
+{
+    public AudioClip soundClip;                         // 재생할 효과음
+    public AudioMixerGroup outputGroup;                 // 오디오 믹서 그룹
+    public float triggerRadius = 10f;                   // 최대 감지 거리
+    public LayerMask obstacleLayer;                     // 장애물 레이어
+    public Transform player;                            // 플레이어 Transform
+
+    private bool hasPlayed = false;                     // 중복 재생 방지
+
+    void Update()
+    {
+        if (hasPlayed) return;
+
+        float distance = Vector3.Distance(transform.position, player.position);
+
+        if (distance <= triggerRadius)
+        {
+            // 플레이어와의 직선 거리 상에 장애물이 있는지 Raycast로 확인
+            Vector3 direction = (player.position - transform.position).normalized;
+            float dist = Vector3.Distance(transform.position, player.position);
+
+            if (!Physics.Raycast(transform.position, direction, dist, obstacleLayer))
+            {
+                PlaySound();
+                hasPlayed = true;
+            }
+        }
+    }
+
+    void PlaySound()
+    {
+        AudioSource audio = new GameObject("3DSound").AddComponent<AudioSource>();
+        audio.transform.position = transform.position;
+        audio.clip = soundClip;
+        audio.outputAudioMixerGroup = outputGroup;
+        audio.spatialBlend = 1f;         // 3D 사운드
+        audio.minDistance = 1f;
+        audio.maxDistance = triggerRadius;
+        audio.Play();
+
+        Destroy(audio.gameObject, soundClip.length + 1f);
+    }
+}

--- a/Assets/00WorkSpace/KDJ/soundScript/SmartSoundTrigger.cs.meta
+++ b/Assets/00WorkSpace/KDJ/soundScript/SmartSoundTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28882b838ff4c49eea32dbcdd961988c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION


## 요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)
CombatSoundTrigger:Unity에서 전투Combat 관련 사운드를 재생하는 기능을 담당,공격과 피격 시에 각각 소리를 재생 맞았을 때(피격) 이 메서드를 호출하면 hitSound의 사운드가 재생
ItemPickupSound:아이템을 플레이어가 가까이서 주울 때 효과음을 재생하는 기능
플레이어가 아이템의 트리거 영역에 들어오면,
새로운 오디오 소스 오브젝트를 만들어,
거리 기반(3D) 사운드를 한 번만 재생하고 자동 제거
SmartSoundTrigger:플레이어가 특정 범위 안에 접근했을 때, 장애물 없이 보이면 3D 사운드를 재생하는 스마트 사운드 트리거사운드 효과를 적절한 거리에서 한 번만 재생하는 용도
---

## 작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 작업 1
- 작업 2

---

## 스크린샷 / 녹화
(필요하다면 GIF나 스크린샷을 첨부해 주세요)

---

## 테스트 방법
(직접 테스트해보는 방법을 단계별로 적어주세요)
1. 
2. 

---

## 해야 할 일 / 수정 사항
(아직 남아 있는 문제, 추가로 개선할 부분이나 향후 수정이 필요한 내용을 적어주세요)

---

## 체크리스트

- [ ] 코드가 정상적으로 빌드/실행된다
- [ ] 기능이 정상 동작한다
- [ ] 심각한 버그나 예상치 못한 문제는 없다
