### PR TITLE
[Feat] 플레이어의 맵 이동 제한

### DIFF
--- a/Assets/00WorkSpace/MMJ/BoundaryClamper.cs
+++ b/Assets/00WorkSpace/MMJ/BoundaryClamper.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+public class BoundaryClamper : MonoBehaviour
+{
+    // 맵의 경계 좌표를 설정합니다. Inspector에서 조정해주세요.
+    public float minX;
+    public float maxX;
+    public float minY;
+    public float maxY;
+
+    // 이 트리거에 들어올 게임 오브젝트의 태그를 설정합니다. (예: "Player")
+    public string targetTag = "Player";
+
+    private void OnTriggerStay2D(Collider2D other) // OnTriggerEnter2D도 가능하지만, 돌진 시 안전하게 OnTriggerStay2D 추천
+    {
+        // 대상 오브젝트가 설정된 태그와 일치하는지 확인합니다.
+        if (other.CompareTag(targetTag))
+        {
+            Vector3 clampedPosition = other.transform.position;
+
+            // X 좌표를 맵 경계 내로 제한합니다.
+            clampedPosition.x = Mathf.Clamp(clampedPosition.x, minX, maxX);
+            // Y 좌표를 맵 경계 내로 제한합니다.
+            clampedPosition.y = Mathf.Clamp(clampedPosition.y, minY, maxY);
+
+            // 클램프된 위치를 대상 오브젝트에 적용합니다.
+            other.transform.position = clampedPosition;
+        }
+    }
+}

--- a/Assets/00WorkSpace/MMJ/BoundaryClamper.cs.meta
+++ b/Assets/00WorkSpace/MMJ/BoundaryClamper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba83cb955d1a6e04480c531489dd9f3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00WorkSpace/MMJ/GameScene_MMJ.unity.meta
+++ b/Assets/00WorkSpace/MMJ/GameScene_MMJ.unity.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 91136212e4f10ed4fbeb0eb3887ddd92
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/00WorkSpace/MMJ/LobbyScene_MMJ.unity
+++ b/Assets/00WorkSpace/MMJ/LobbyScene_MMJ.unity
@@ -122,130 +122,15 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1001 &362789785
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7938477912263116750, guid: 102d8565160da5549844bc715985ff86, type: 3}
-      propertyPath: m_Name
-      value: BackendManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 102d8565160da5549844bc715985ff86, type: 3}
---- !u!1 &433647247
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 433647249}
-  - component: {fileID: 433647248}
-  m_Layer: 0
-  m_Name: GameManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &433647248
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 433647247}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ccaaab36d3b2bad4d9d8f7d52e19cf38, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  backendManager: {fileID: 1991358298}
-  uIManager: {fileID: 698875341}
-  networkManager: {fileID: 505055590}
---- !u!4 &433647249
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 433647247}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -10.863025, y: -27.730928, z: -0.40580755}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &505055590 stripped
+--- !u!114 &359598162 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4707523169094455476, guid: 1ede5832d8ae8ba4cb5031f137a61769, type: 3}
-  m_PrefabInstance: {fileID: 1457394303}
+  m_PrefabInstance: {fileID: 1272132428}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a04a13c7873eecd448164323e6394791, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &698875341 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1462700376574079343, guid: d144a3705ce37da48bfdccca0bdf578f, type: 3}
-  m_PrefabInstance: {fileID: 2011407864}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ebde854b5c04484694c7c7a65285d81, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &705507993
@@ -352,7 +237,7 @@ GameObject:
   m_Component:
   - component: {fileID: 896086323}
   - component: {fileID: 896086322}
-  - component: {fileID: 896086321}
+  - component: {fileID: 896086324}
   m_Layer: 0
   m_Name: EventSystem
   m_TagString: Untagged
@@ -360,26 +245,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &896086321
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 896086320}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
 --- !u!114 &896086322
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -410,6 +275,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &896086324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 896086320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_PointAction: {fileID: -1654692200621890270, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MoveAction: {fileID: -8784545083839296357, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_SubmitAction: {fileID: 392368643174621059, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_CancelAction: {fileID: 7727032971491509709, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_LeftClickAction: {fileID: 3001919216989983466, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_MiddleClickAction: {fileID: -2185481485913320682, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_RightClickAction: {fileID: -4090225696740746782, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_ScrollWheelAction: {fileID: 6240969308177333660, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDevicePositionAction: {fileID: 6564999863303420839, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
+  m_ScrollDeltaPerTick: 6
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -523,7 +419,18 @@ MonoBehaviour:
   m_CropFrameX: 0
   m_CropFrameY: 0
   m_StretchFill: 0
---- !u!1001 &1457394303
+--- !u!114 &1251636947 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 400366769537663036, guid: 102d8565160da5549844bc715985ff86, type: 3}
+  m_PrefabInstance: {fileID: 1574633069294498284}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 932e349bc4ea0f84f83f21ba1c8b3f45, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1272132428
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -580,18 +487,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1ede5832d8ae8ba4cb5031f137a61769, type: 3}
---- !u!114 &1991358298 stripped
+--- !u!114 &2045375954 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 400366769537663036, guid: 102d8565160da5549844bc715985ff86, type: 3}
-  m_PrefabInstance: {fileID: 362789785}
+  m_CorrespondingSourceObject: {fileID: 1462700376574079343, guid: d144a3705ce37da48bfdccca0bdf578f, type: 3}
+  m_PrefabInstance: {fileID: 1454573451503400698}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 932e349bc4ea0f84f83f21ba1c8b3f45, type: 3}
+  m_Script: {fileID: 11500000, guid: 4ebde854b5c04484694c7c7a65285d81, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &2011407864
+--- !u!1001 &1454573451503400698
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
@@ -648,6 +555,132 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d144a3705ce37da48bfdccca0bdf578f, type: 3}
+--- !u!1001 &1574633069294498284
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3848045326574205255, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7938477912263116750, guid: 102d8565160da5549844bc715985ff86, type: 3}
+      propertyPath: m_Name
+      value: BackendManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 102d8565160da5549844bc715985ff86, type: 3}
+--- !u!1001 &6426554421691230224
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 515487935531076717, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_Name
+      value: GameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 5205457970241702463, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: uIManager
+      value: 
+      objectReference: {fileID: 2045375954}
+    - target: {fileID: 5205457970241702463, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: backendManager
+      value: 
+      objectReference: {fileID: 1251636947}
+    - target: {fileID: 5205457970241702463, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: networkManager
+      value: 
+      objectReference: {fileID: 359598162}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.501969
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 15.129771
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.0351412
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8644365985809865814, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5c02dbd2d5f88184a9ea379e7b744444, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -655,7 +688,7 @@ SceneRoots:
   - {fileID: 963194228}
   - {fileID: 705507995}
   - {fileID: 896086323}
-  - {fileID: 2011407864}
-  - {fileID: 1457394303}
-  - {fileID: 362789785}
-  - {fileID: 433647249}
+  - {fileID: 1574633069294498284}
+  - {fileID: 1454573451503400698}
+  - {fileID: 1272132428}
+  - {fileID: 6426554421691230224}

--- a/Assets/00WorkSpace/MMJ/LobbyScene_MMJ.unity.meta
+++ b/Assets/00WorkSpace/MMJ/LobbyScene_MMJ.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e7add9b3ecca9c40a293b698840646c
+guid: 9366505623f08084fab3170d45ab2a71
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/Assets/00WorkSpace/MMJ/MMJ_GameScene.unity.meta
+++ b/Assets/00WorkSpace/MMJ/MMJ_GameScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2826593b5aca94b408a714094d13af93
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/00WorkSpace/MMJ/PlayerTeleporter.cs
+++ b/Assets/00WorkSpace/MMJ/PlayerTeleporter.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+public class DirectionalTeleporter : MonoBehaviour
+{
+    public enum TeleportDirection { Left, Right, Top, Bottom }
+
+    [SerializeField] private TeleportDirection direction;
+    [SerializeField] private float teleportCoordinate = 74f; // 텔레포트할 좌표값 (기본값 74)
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        // Player 태그를 가진 오브젝트만 처리
+        if (collision.CompareTag("Player"))
+        {
+            Vector3 playerPosition = collision.transform.position;
+
+            // 방향에 따라 적절한 좌표 설정
+            switch (direction)
+            {
+                case TeleportDirection.Left:
+                    playerPosition.x = -teleportCoordinate; // 왼쪽 텔레포터: x = -74
+                    break;
+
+                case TeleportDirection.Right:
+                    playerPosition.x = teleportCoordinate;  // 오른쪽 텔레포터: x = 74
+                    break;
+
+                case TeleportDirection.Top:
+                    playerPosition.y = teleportCoordinate;  // 위쪽 텔레포터: y = 74
+                    break;
+
+                case TeleportDirection.Bottom:
+                    playerPosition.y = -teleportCoordinate; // 아래쪽 텔레포터: y = -74
+                    break;
+            }
+
+            // 플레이어 위치 변경
+            collision.transform.position = playerPosition;
+
+            // 디버그 로그 (필요시 주석 해제)
+            // Debug.Log($"플레이어를 {direction} 방향 경계로 텔레포트했습니다: {playerPosition}");
+        }
+    }
+}

--- a/Assets/00WorkSpace/MMJ/PlayerTeleporter.cs.meta
+++ b/Assets/00WorkSpace/MMJ/PlayerTeleporter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3261346e268abef4eabcdcdcf6f3fbfb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -23,5 +23,8 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/00WorkSpace/MMJ/LobbyScene_MMJ.unity
     guid: 9366505623f08084fab3170d45ab2a71
+  - enabled: 1
+    path: Assets/00WorkSpace/MMJ/MMJ_GameScene.unity
+    guid: 2826593b5aca94b408a714094d13af93
   m_configObjects:
     com.unity.input.settings: {fileID: 11400000, guid: 61ef2b17c67d4cf4fa150ae02e7c7606, type: 2}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -21,10 +21,7 @@ EditorBuildSettings:
     path: Assets/00WorkSpace/SJH/SJH_Scene.unity
     guid: d88a2bfdc7ed85b4a86ff2f799939f1b
   - enabled: 1
-    path: Assets/00WorkSpace/MMJ/GameScene_MMJ.unity
-    guid: 91136212e4f10ed4fbeb0eb3887ddd92
-  - enabled: 1
     path: Assets/00WorkSpace/MMJ/LobbyScene_MMJ.unity
-    guid: 1e7add9b3ecca9c40a293b698840646c
+    guid: 9366505623f08084fab3170d45ab2a71
   m_configObjects:
     com.unity.input.settings: {fileID: 11400000, guid: 61ef2b17c67d4cf4fa150ae02e7c7606, type: 2}


### PR DESCRIPTION
## 요약
플레이어의 맵 이동을 제한하는 기능을 구현
---

## 작업 내용
<img width="161" height="49" alt="image" src="https://github.com/user-attachments/assets/4ac8a5df-9f29-4d14-aec9-f9aa540abd93" />

- Border = 경계를 만들어서 플레이어를 맵 밖으로 나가지 못 하게 함
- TelePoter = 플레이어가 스킬을 통해 맵 밖으로 나갔을 경우 일정 좌표로 플레이어를 텔레포트 시키는 역할 


---

## 적용 방법
인게임 씬 하이어라키에 Border 프리펩 추가

-> Border 위치
<img width="450" height="136" alt="image" src="https://github.com/user-attachments/assets/55d1855f-10dc-45ce-a7bd-11e55c953ed2" />




---

## 해야 할 일 / 수정 사항
새로 만들어서 장애물이 있는 맵을 만들었는데 이건 Border의 구조가 좀 복잡해질 것 같아서 외곽벽이 아닌 맵 안에 있는 장애물에 대해선 그냥 신경쓰지 않고 진행함 
(그렇게 판단한 까닭은 현재 Border의 구조는 사방을 둘러싼 트리거콜라이더에 의해 좌표값으로 제어받는 것인데 장애물 하나하나마다 개별적용의 어려움이 있다고 판단)


---

## 체크리스트

- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다
